### PR TITLE
Change PHP's opcache.revalidate_freq to 2 seconds

### DIFF
--- a/5.5/drupal-x-opcache.ini
+++ b/5.5/drupal-x-opcache.ini
@@ -1,0 +1,1 @@
+opcache.revalidate_freq=2

--- a/5.6/drupal-x-opcache.ini
+++ b/5.6/drupal-x-opcache.ini
@@ -1,0 +1,1 @@
+opcache.revalidate_freq=2

--- a/7.0/drupal-x-opcache.ini
+++ b/7.0/drupal-x-opcache.ini
@@ -1,0 +1,1 @@
+opcache.revalidate_freq=2


### PR DESCRIPTION
60 seconds (current setting) makes default for non-dev images, but in dev environments can be too much. 2 seconds is default value and seems to be OK for most development environments.
