### PR TITLE
Add php SOAP extension

### DIFF
--- a/5.6/Dockerfile-alpine-cli
+++ b/5.6/Dockerfile-alpine-cli
@@ -4,7 +4,7 @@ MAINTAINER drupal-docker
 VOLUME /var/www/html
 WORKDIR /var/www/html
 
-RUN apk add --no-cache --virtual .dd-build-deps libpng-dev libjpeg-turbo-dev postgresql-dev $PHPIZE_DEPS \
+RUN apk add --no-cache --virtual .dd-build-deps libpng-dev libjpeg-turbo-dev postgresql-dev libxml2-dev $PHPIZE_DEPS \
    && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
    && docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip \
    && docker-php-ext-install opcache bcmath soap \
@@ -16,7 +16,7 @@ RUN apk add --no-cache --virtual .dd-build-deps libpng-dev libjpeg-turbo-dev pos
    && php -r "unlink('composer-setup.php');" \
    && mv composer.phar /usr/local/bin/composer \
    && echo "export PATH=~/.composer/vendor/bin:\$PATH" >> ~/.bash_profile \
-   && apk add --no-cache sudo git libpng libjpeg libpq \
+   && apk add --no-cache sudo git libpng libjpeg libpq libxml2 \
    && apk del .dd-build-deps
 
 COPY drupal-*.ini /usr/local/etc/php/conf.d/

--- a/5.6/Dockerfile-alpine-cli
+++ b/5.6/Dockerfile-alpine-cli
@@ -7,7 +7,7 @@ WORKDIR /var/www/html
 RUN apk add --no-cache --virtual .dd-build-deps libpng-dev libjpeg-turbo-dev postgresql-dev $PHPIZE_DEPS \
    && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
    && docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip \
-   && docker-php-ext-install opcache bcmath \
+   && docker-php-ext-install opcache bcmath soap \
    && pecl install redis-2.2.8 \
    && docker-php-ext-enable redis \
    && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \

--- a/5.6/Dockerfile-alpine-fpm
+++ b/5.6/Dockerfile-alpine-fpm
@@ -6,7 +6,7 @@ VOLUME /var/www/html
 RUN apk add --no-cache --virtual .dd-build-deps libpng-dev libjpeg-turbo-dev postgresql-dev $PHPIZE_DEPS \
    && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
    && docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip \
-   && docker-php-ext-install opcache bcmath \
+   && docker-php-ext-install opcache bcmath soap \
    && pecl install redis-2.2.8 \
    && docker-php-ext-enable redis \
    && apk add --no-cache libpng libjpeg libpq \

--- a/5.6/Dockerfile-alpine-fpm
+++ b/5.6/Dockerfile-alpine-fpm
@@ -3,13 +3,13 @@ MAINTAINER drupal-docker
 
 VOLUME /var/www/html
 
-RUN apk add --no-cache --virtual .dd-build-deps libpng-dev libjpeg-turbo-dev postgresql-dev $PHPIZE_DEPS \
+RUN apk add --no-cache --virtual .dd-build-deps libpng-dev libjpeg-turbo-dev postgresql-dev libxml2-dev $PHPIZE_DEPS \
    && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
    && docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip \
    && docker-php-ext-install opcache bcmath soap \
    && pecl install redis-2.2.8 \
    && docker-php-ext-enable redis \
-   && apk add --no-cache libpng libjpeg libpq \
+   && apk add --no-cache libpng libjpeg libpq libxml2 \
    && apk del .dd-build-deps
 
 COPY drupal-*.ini /usr/local/etc/php/conf.d/

--- a/5.6/Dockerfile-apache
+++ b/5.6/Dockerfile-apache
@@ -3,7 +3,7 @@ MAINTAINER drupal-docker
 
 VOLUME /var/www/html
 
-RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev \
+RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev libxml2-dev \
 	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
 	&& docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip \
 	&& docker-php-ext-install opcache bcmath soap \

--- a/5.6/Dockerfile-apache
+++ b/5.6/Dockerfile-apache
@@ -6,7 +6,7 @@ VOLUME /var/www/html
 RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev \
 	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
 	&& docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip \
-	&& docker-php-ext-install opcache bcmath \
+	&& docker-php-ext-install opcache bcmath soap \
 	&& pecl install redis-2.2.8 \
   && docker-php-ext-enable redis \
 	&& a2enmod rewrite \

--- a/5.6/Dockerfile-cli
+++ b/5.6/Dockerfile-cli
@@ -4,7 +4,7 @@ MAINTAINER drupal-docker
 VOLUME /var/www/html
 WORKDIR /var/www/html
 
-RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev sudo git mysql-client openssh-client rsync \
+RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev libxml2-dev sudo git mysql-client openssh-client rsync \
   && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
   && docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip \
   && docker-php-ext-install opcache bcmath soap \

--- a/5.6/Dockerfile-cli
+++ b/5.6/Dockerfile-cli
@@ -7,7 +7,7 @@ WORKDIR /var/www/html
 RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev sudo git mysql-client openssh-client rsync \
   && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
   && docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip \
-  && docker-php-ext-install opcache bcmath \
+  && docker-php-ext-install opcache bcmath soap \
   && pecl install redis-2.2.8 \
   && docker-php-ext-enable redis \
   && curl -sS https://getcomposer.org/installer | php \

--- a/5.6/Dockerfile-fpm
+++ b/5.6/Dockerfile-fpm
@@ -3,7 +3,7 @@ MAINTAINER drupal-docker
 
 VOLUME /var/www/html
 
-RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev \
+RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev libxml2-dev \
 	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
 	&& docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip \
 	&& docker-php-ext-install opcache bcmath soap \

--- a/5.6/Dockerfile-fpm
+++ b/5.6/Dockerfile-fpm
@@ -6,7 +6,7 @@ VOLUME /var/www/html
 RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev \
 	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
 	&& docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip \
-	&& docker-php-ext-install opcache bcmath \
+	&& docker-php-ext-install opcache bcmath soap \
 	&& pecl install redis-2.2.8 \
   && docker-php-ext-enable redis \
 	&& rm -rf /var/lib/apt/lists/*

--- a/7.0/Dockerfile-alpine-cli
+++ b/7.0/Dockerfile-alpine-cli
@@ -7,7 +7,7 @@ WORKDIR /var/www/html
 RUN apk add --no-cache --virtual .dd-build-deps libpng-dev libjpeg-turbo-dev postgresql-dev $PHPIZE_DEPS \
    && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
    && docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip \
-   && docker-php-ext-install opcache bcmath \
+   && docker-php-ext-install opcache bcmath soap \
    && pecl install redis-3.1.1 \
    && docker-php-ext-enable redis \
    && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \

--- a/7.0/Dockerfile-alpine-cli
+++ b/7.0/Dockerfile-alpine-cli
@@ -4,7 +4,7 @@ MAINTAINER drupal-docker
 VOLUME /var/www/html
 WORKDIR /var/www/html
 
-RUN apk add --no-cache --virtual .dd-build-deps libpng-dev libjpeg-turbo-dev postgresql-dev $PHPIZE_DEPS \
+RUN apk add --no-cache --virtual .dd-build-deps libpng-dev libjpeg-turbo-dev postgresql-dev libxml2-dev $PHPIZE_DEPS \
    && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
    && docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip \
    && docker-php-ext-install opcache bcmath soap \
@@ -16,7 +16,7 @@ RUN apk add --no-cache --virtual .dd-build-deps libpng-dev libjpeg-turbo-dev pos
    && php -r "unlink('composer-setup.php');" \
    && mv composer.phar /usr/local/bin/composer \
    && echo "export PATH=~/.composer/vendor/bin:\$PATH" >> ~/.bash_profile \
-   && apk add --no-cache sudo git libpng libjpeg libpq \
+   && apk add --no-cache sudo git libpng libjpeg libpq libxml2 \
    && apk del .dd-build-deps
 
 COPY drupal-*.ini /usr/local/etc/php/conf.d/

--- a/7.0/Dockerfile-alpine-fpm
+++ b/7.0/Dockerfile-alpine-fpm
@@ -3,13 +3,13 @@ MAINTAINER drupal-docker
 
 VOLUME /var/www/html
 
-RUN apk add --no-cache --virtual .dd-build-deps libpng-dev libjpeg-turbo-dev postgresql-dev $PHPIZE_DEPS \
+RUN apk add --no-cache --virtual .dd-build-deps libpng-dev libjpeg-turbo-dev postgresql-dev libxml2-dev $PHPIZE_DEPS \
    && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
    && docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip \
    && docker-php-ext-install opcache bcmath soap \
    && pecl install redis-3.1.1 \
    && docker-php-ext-enable redis \
-   && apk add --no-cache libpng libjpeg libpq \
+   && apk add --no-cache libpng libjpeg libpq libxml2 \
    && apk del .dd-build-deps
 
 COPY drupal-*.ini /usr/local/etc/php/conf.d/

--- a/7.0/Dockerfile-alpine-fpm
+++ b/7.0/Dockerfile-alpine-fpm
@@ -6,7 +6,7 @@ VOLUME /var/www/html
 RUN apk add --no-cache --virtual .dd-build-deps libpng-dev libjpeg-turbo-dev postgresql-dev $PHPIZE_DEPS \
    && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
    && docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip \
-   && docker-php-ext-install opcache bcmath \
+   && docker-php-ext-install opcache bcmath soap \
    && pecl install redis-3.1.1 \
    && docker-php-ext-enable redis \
    && apk add --no-cache libpng libjpeg libpq \

--- a/7.0/Dockerfile-apache
+++ b/7.0/Dockerfile-apache
@@ -3,7 +3,7 @@ MAINTAINER drupal-docker
 
 VOLUME /var/www/html
 
-RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev \
+RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev libxml2-dev \
 	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
 	&& docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip \
 	&& docker-php-ext-install opcache bcmath soap \

--- a/7.0/Dockerfile-apache
+++ b/7.0/Dockerfile-apache
@@ -6,7 +6,7 @@ VOLUME /var/www/html
 RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev \
 	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
 	&& docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip \
-	&& docker-php-ext-install opcache bcmath \
+	&& docker-php-ext-install opcache bcmath soap \
   && pecl install redis-3.1.1 \
   && docker-php-ext-enable redis \
 	&& a2enmod rewrite \

--- a/7.0/Dockerfile-cli
+++ b/7.0/Dockerfile-cli
@@ -7,7 +7,7 @@ WORKDIR /var/www/html
 RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev sudo git mysql-client openssh-client rsync \
   && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
   && docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip \
-  && docker-php-ext-install opcache bcmath \
+  && docker-php-ext-install opcache bcmath soap \
   && pecl install redis-3.1.1 \
   && docker-php-ext-enable redis \
   && curl -sS https://getcomposer.org/installer | php \

--- a/7.0/Dockerfile-cli
+++ b/7.0/Dockerfile-cli
@@ -4,7 +4,7 @@ MAINTAINER drupal-docker
 VOLUME /var/www/html
 WORKDIR /var/www/html
 
-RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev sudo git mysql-client openssh-client rsync \
+RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev libxml2-dev sudo git mysql-client openssh-client rsync \
   && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
   && docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip \
   && docker-php-ext-install opcache bcmath soap \

--- a/7.0/Dockerfile-fpm
+++ b/7.0/Dockerfile-fpm
@@ -4,7 +4,7 @@ MAINTAINER drupal-docker
 
 VOLUME /var/www/html
 
-RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev \
+RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev libxml2-dev \
 	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
 	&& docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip \
 	&& docker-php-ext-install opcache bcmath soap \

--- a/7.0/Dockerfile-fpm
+++ b/7.0/Dockerfile-fpm
@@ -7,7 +7,7 @@ VOLUME /var/www/html
 RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev \
 	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
 	&& docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip \
-	&& docker-php-ext-install opcache bcmath \
+	&& docker-php-ext-install opcache bcmath soap \
   && pecl install redis-3.1.1 \
   && docker-php-ext-enable redis \
 	&& rm -rf /var/lib/apt/lists/*

--- a/7.1/Dockerfile-alpine-cli
+++ b/7.1/Dockerfile-alpine-cli
@@ -7,7 +7,7 @@ WORKDIR /var/www/html
 RUN apk add --no-cache --virtual .dd-build-deps libpng-dev libjpeg-turbo-dev postgresql-dev $PHPIZE_DEPS \
    && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
    && docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip \
-   && docker-php-ext-install opcache bcmath \
+   && docker-php-ext-install opcache bcmath soap \
    && pecl install redis-3.1.1 \
    && docker-php-ext-enable redis \
    && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \

--- a/7.1/Dockerfile-alpine-cli
+++ b/7.1/Dockerfile-alpine-cli
@@ -4,7 +4,7 @@ MAINTAINER drupal-docker
 VOLUME /var/www/html
 WORKDIR /var/www/html
 
-RUN apk add --no-cache --virtual .dd-build-deps libpng-dev libjpeg-turbo-dev postgresql-dev $PHPIZE_DEPS \
+RUN apk add --no-cache --virtual .dd-build-deps libpng-dev libjpeg-turbo-dev postgresql-dev libxml2-dev $PHPIZE_DEPS \
    && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
    && docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip \
    && docker-php-ext-install opcache bcmath soap \
@@ -16,7 +16,7 @@ RUN apk add --no-cache --virtual .dd-build-deps libpng-dev libjpeg-turbo-dev pos
    && php -r "unlink('composer-setup.php');" \
    && mv composer.phar /usr/local/bin/composer \
    && echo "export PATH=~/.composer/vendor/bin:\$PATH" >> ~/.bash_profile \
-   && apk add --no-cache sudo git libpng libjpeg libpq \
+   && apk add --no-cache sudo git libpng libjpeg libpq libxml2 \
    && apk del .dd-build-deps
 
 COPY drupal-*.ini /usr/local/etc/php/conf.d/

--- a/7.1/Dockerfile-alpine-fpm
+++ b/7.1/Dockerfile-alpine-fpm
@@ -3,13 +3,13 @@ MAINTAINER drupal-docker
 
 VOLUME /var/www/html
 
-RUN apk add --no-cache --virtual .dd-build-deps libpng-dev libjpeg-turbo-dev postgresql-dev $PHPIZE_DEPS \
+RUN apk add --no-cache --virtual .dd-build-deps libpng-dev libjpeg-turbo-dev postgresql-dev libxml2-dev $PHPIZE_DEPS \
    && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
    && docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip \
    && docker-php-ext-install opcache bcmath soap \
    && pecl install redis-3.1.1 \
    && docker-php-ext-enable redis \
-   && apk add --no-cache libpng libjpeg libpq \
+   && apk add --no-cache libpng libjpeg libpq libxml2 \
    && apk del .dd-build-deps
 
 COPY drupal-*.ini /usr/local/etc/php/conf.d/

--- a/7.1/Dockerfile-alpine-fpm
+++ b/7.1/Dockerfile-alpine-fpm
@@ -6,7 +6,7 @@ VOLUME /var/www/html
 RUN apk add --no-cache --virtual .dd-build-deps libpng-dev libjpeg-turbo-dev postgresql-dev $PHPIZE_DEPS \
    && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
    && docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip \
-   && docker-php-ext-install opcache bcmath \
+   && docker-php-ext-install opcache bcmath soap \
    && pecl install redis-3.1.1 \
    && docker-php-ext-enable redis \
    && apk add --no-cache libpng libjpeg libpq \

--- a/7.1/Dockerfile-apache
+++ b/7.1/Dockerfile-apache
@@ -3,7 +3,7 @@ MAINTAINER drupal-docker
 
 VOLUME /var/www/html
 
-RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev \
+RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev libxml2-dev \
 	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
 	&& docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip \
 	&& docker-php-ext-install opcache bcmath soap \

--- a/7.1/Dockerfile-apache
+++ b/7.1/Dockerfile-apache
@@ -6,7 +6,7 @@ VOLUME /var/www/html
 RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev \
 	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
 	&& docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip \
-	&& docker-php-ext-install opcache bcmath \
+	&& docker-php-ext-install opcache bcmath soap \
   && pecl install redis-3.1.1 \
   && docker-php-ext-enable redis \
 	&& a2enmod rewrite \

--- a/7.1/Dockerfile-cli
+++ b/7.1/Dockerfile-cli
@@ -7,7 +7,7 @@ WORKDIR /var/www/html
 RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev sudo git mysql-client openssh-client rsync \
   && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
   && docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip \
-  && docker-php-ext-install opcache bcmath \
+  && docker-php-ext-install opcache bcmath soap \
   && pecl install redis-3.1.1 \
   && docker-php-ext-enable redis \
   && curl -sS https://getcomposer.org/installer | php \

--- a/7.1/Dockerfile-cli
+++ b/7.1/Dockerfile-cli
@@ -4,7 +4,7 @@ MAINTAINER drupal-docker
 VOLUME /var/www/html
 WORKDIR /var/www/html
 
-RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev sudo git mysql-client openssh-client rsync \
+RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev libxml2-dev sudo git mysql-client openssh-client rsync \
   && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
   && docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip \
   && docker-php-ext-install opcache bcmath soap \

--- a/7.1/Dockerfile-fpm
+++ b/7.1/Dockerfile-fpm
@@ -6,7 +6,7 @@ VOLUME /var/www/html
 RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev \
 	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
 	&& docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip \
-	&& docker-php-ext-install opcache bcmath \
+	&& docker-php-ext-install opcache bcmath soap \
   && pecl install redis-3.1.1 \
   && docker-php-ext-enable redis \
 	&& rm -rf /var/lib/apt/lists/*

--- a/7.1/Dockerfile-fpm
+++ b/7.1/Dockerfile-fpm
@@ -3,7 +3,7 @@ MAINTAINER drupal-docker
 
 VOLUME /var/www/html
 
-RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev \
+RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev libxml2-dev \
 	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
 	&& docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip \
 	&& docker-php-ext-install opcache bcmath soap \


### PR DESCRIPTION
> The SOAP extension can be used to write SOAP Servers and Clients. It supports subsets of » SOAP 1.1, » SOAP 1.2 and » WSDL 1.1 specifications.