### PR TITLE
Get composer with curl

### DIFF
--- a/5.6/Dockerfile-alpine-cli
+++ b/5.6/Dockerfile-alpine-cli
@@ -10,10 +10,7 @@ RUN apk add --no-cache --virtual .dd-build-deps libpng-dev libjpeg-turbo-dev pos
    && docker-php-ext-install opcache bcmath soap \
    && pecl install redis-2.2.8 \
    && docker-php-ext-enable redis \
-   && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-   && php -r "if (hash_file('SHA384', 'composer-setup.php') === '669656bab3166a7aff8a7506b8cb2d1c292f042046c5a994c43155c0be6190fa0355160742ab2e1c88d40d5be660b410') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
-   && php composer-setup.php \
-   && php -r "unlink('composer-setup.php');" \
+   && curl -sS https://getcomposer.org/installer | php \
    && mv composer.phar /usr/local/bin/composer \
    && echo "export PATH=~/.composer/vendor/bin:\$PATH" >> ~/.bash_profile \
    && apk add --no-cache sudo git libpng libjpeg libpq libxml2 mysql-client openssh-client rsync \

--- a/7.0/Dockerfile-alpine-cli
+++ b/7.0/Dockerfile-alpine-cli
@@ -10,10 +10,7 @@ RUN apk add --no-cache --virtual .dd-build-deps libpng-dev libjpeg-turbo-dev pos
    && docker-php-ext-install opcache bcmath soap \
    && pecl install redis-3.1.1 \
    && docker-php-ext-enable redis \
-   && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-   && php -r "if (hash_file('SHA384', 'composer-setup.php') === '669656bab3166a7aff8a7506b8cb2d1c292f042046c5a994c43155c0be6190fa0355160742ab2e1c88d40d5be660b410') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
-   && php composer-setup.php \
-   && php -r "unlink('composer-setup.php');" \
+   && curl -sS https://getcomposer.org/installer | php \
    && mv composer.phar /usr/local/bin/composer \
    && echo "export PATH=~/.composer/vendor/bin:\$PATH" >> ~/.bash_profile \
    && apk add --no-cache sudo git libpng libjpeg libpq libxml2 mysql-client openssh-client rsync \

--- a/7.1/Dockerfile-alpine-cli
+++ b/7.1/Dockerfile-alpine-cli
@@ -10,10 +10,7 @@ RUN apk add --no-cache --virtual .dd-build-deps libpng-dev libjpeg-turbo-dev pos
    && docker-php-ext-install opcache bcmath soap \
    && pecl install redis-3.1.1 \
    && docker-php-ext-enable redis \
-   && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-   && php -r "if (hash_file('SHA384', 'composer-setup.php') === '669656bab3166a7aff8a7506b8cb2d1c292f042046c5a994c43155c0be6190fa0355160742ab2e1c88d40d5be660b410') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
-   && php composer-setup.php \
-   && php -r "unlink('composer-setup.php');" \
+   && curl -sS https://getcomposer.org/installer | php \
    && mv composer.phar /usr/local/bin/composer \
    && echo "export PATH=~/.composer/vendor/bin:\$PATH" >> ~/.bash_profile \
    && apk add --no-cache sudo git libpng libjpeg libpq libxml2 mysql-client openssh-client rsync \


### PR DESCRIPTION
CURL has been added to official php alpine docker image. We can now download composer using curl to avoid broken builds whenever new version of composer was released.