### PR TITLE
Lock on version number for xdebug

### DIFF
--- a/5.6/Dockerfile-alpine-cli
+++ b/5.6/Dockerfile-alpine-cli
@@ -2,7 +2,7 @@ FROM drupaldocker/php:5.6-alpine-cli
 MAINTAINER drupal-docker
 
 RUN apk add --no-cache --virtual .dd-build-deps $PHPIZE_DEPS \
- && pecl install xdebug-beta \
+ && pecl install xdebug-2.5.5 \
  && docker-php-ext-enable xdebug \
  && apk del .dd-build-deps
 

--- a/5.6/Dockerfile-alpine-fpm
+++ b/5.6/Dockerfile-alpine-fpm
@@ -2,7 +2,7 @@ FROM drupaldocker/php:5.6-alpine-fpm
 MAINTAINER drupal-docker
 
 RUN apk add --no-cache --virtual .dd-build-deps $PHPIZE_DEPS \
- && pecl install xdebug-beta \
+ && pecl install xdebug-2.5.5 \
  && docker-php-ext-enable xdebug \
  && apk del .dd-build-deps
 

--- a/5.6/Dockerfile-apache
+++ b/5.6/Dockerfile-apache
@@ -1,7 +1,7 @@
 FROM drupaldocker/php:5.6-apache
 MAINTAINER drupal-docker
 
-RUN pecl install xdebug-beta \
+RUN pecl install xdebug-2.5.5 \
  && docker-php-ext-enable xdebug
 
 COPY drupal-*.ini /usr/local/etc/php/conf.d/

--- a/5.6/Dockerfile-cli
+++ b/5.6/Dockerfile-cli
@@ -1,7 +1,7 @@
 FROM drupaldocker/php:5.6-cli
 MAINTAINER drupal-docker
 
-RUN pecl install xdebug-beta \
+RUN pecl install xdebug-2.5.5 \
  && docker-php-ext-enable xdebug
 
 COPY drupal-*.ini /usr/local/etc/php/conf.d/

--- a/5.6/Dockerfile-fpm
+++ b/5.6/Dockerfile-fpm
@@ -1,7 +1,7 @@
 FROM drupaldocker/php:5.6-fpm
 MAINTAINER drupal-docker
 
-RUN pecl install xdebug-beta \
+RUN pecl install xdebug-2.5.5 \
  && docker-php-ext-enable xdebug
 
 COPY drupal-*.ini /usr/local/etc/php/conf.d/

--- a/7.0/Dockerfile-alpine-cli
+++ b/7.0/Dockerfile-alpine-cli
@@ -2,7 +2,7 @@ FROM drupaldocker/php:7.0-alpine-cli
 MAINTAINER drupal-docker
 
 RUN apk add --no-cache --virtual .dd-build-deps $PHPIZE_DEPS \
- && pecl install xdebug-beta \
+ && pecl install xdebug-2.6.0beta1 \
  && docker-php-ext-enable xdebug \
  && apk del .dd-build-deps
 

--- a/7.0/Dockerfile-alpine-fpm
+++ b/7.0/Dockerfile-alpine-fpm
@@ -2,7 +2,7 @@ FROM drupaldocker/php:7.0-alpine-fpm
 MAINTAINER drupal-docker
 
 RUN apk add --no-cache --virtual .dd-build-deps $PHPIZE_DEPS \
- && pecl install xdebug-beta \
+ && pecl install xdebug-2.6.0beta1 \
  && docker-php-ext-enable xdebug \
  && apk del .dd-build-deps
 

--- a/7.0/Dockerfile-apache
+++ b/7.0/Dockerfile-apache
@@ -1,7 +1,7 @@
 FROM drupaldocker/php:7.0-apache
 MAINTAINER drupal-docker
 
-RUN pecl install xdebug-beta \
+RUN pecl install xdebug-2.6.0beta1 \
  && docker-php-ext-enable xdebug
 
 COPY drupal-*.ini /usr/local/etc/php/conf.d/

--- a/7.0/Dockerfile-cli
+++ b/7.0/Dockerfile-cli
@@ -1,7 +1,7 @@
 FROM drupaldocker/php:7.0-cli
 MAINTAINER drupal-docker
 
-RUN pecl install xdebug-beta \
+RUN pecl install xdebug-2.6.0beta1 \
  && docker-php-ext-enable xdebug
 
 COPY drupal-*.ini /usr/local/etc/php/conf.d/

--- a/7.0/Dockerfile-fpm
+++ b/7.0/Dockerfile-fpm
@@ -1,7 +1,7 @@
 FROM drupaldocker/php:7.0-fpm
 MAINTAINER drupal-docker
 
-RUN pecl install xdebug-beta \
+RUN pecl install xdebug-2.6.0beta1 \
  && docker-php-ext-enable xdebug
 
 COPY drupal-*.ini /usr/local/etc/php/conf.d/

--- a/7.1/Dockerfile-alpine-cli
+++ b/7.1/Dockerfile-alpine-cli
@@ -2,7 +2,7 @@ FROM drupaldocker/php:7.1-alpine-cli
 MAINTAINER drupal-docker
 
 RUN apk add --no-cache --virtual .dd-build-deps $PHPIZE_DEPS \
- && pecl install xdebug-beta \
+ && pecl install xdebug-2.6.0beta1 \
  && docker-php-ext-enable xdebug \
  && apk del .dd-build-deps
 

--- a/7.1/Dockerfile-alpine-fpm
+++ b/7.1/Dockerfile-alpine-fpm
@@ -2,7 +2,7 @@ FROM drupaldocker/php:7.1-alpine-fpm
 MAINTAINER drupal-docker
 
 RUN apk add --no-cache --virtual .dd-build-deps $PHPIZE_DEPS \
- && pecl install xdebug-beta \
+ && pecl install xdebug-2.6.0beta1 \
  && docker-php-ext-enable xdebug \
  && apk del .dd-build-deps
 

--- a/7.1/Dockerfile-apache
+++ b/7.1/Dockerfile-apache
@@ -1,7 +1,7 @@
 FROM drupaldocker/php:7.1-apache
 MAINTAINER drupal-docker
 
-RUN pecl install xdebug-beta \
+RUN pecl install xdebug-2.6.0beta1 \
  && docker-php-ext-enable xdebug
 
 COPY drupal-*.ini /usr/local/etc/php/conf.d/

--- a/7.1/Dockerfile-cli
+++ b/7.1/Dockerfile-cli
@@ -1,7 +1,7 @@
 FROM drupaldocker/php:7.1-cli
 MAINTAINER drupal-docker
 
-RUN pecl install xdebug-beta \
+RUN pecl install xdebug-2.6.0beta1 \
  && docker-php-ext-enable xdebug
 
 COPY drupal-*.ini /usr/local/etc/php/conf.d/

--- a/7.1/Dockerfile-fpm
+++ b/7.1/Dockerfile-fpm
@@ -1,7 +1,7 @@
 FROM drupaldocker/php:7.1-fpm
 MAINTAINER drupal-docker
 
-RUN pecl install xdebug-beta \
+RUN pecl install xdebug-2.6.0beta1 \
  && docker-php-ext-enable xdebug
 
 COPY drupal-*.ini /usr/local/etc/php/conf.d/


### PR DESCRIPTION
This PR introduces explicit version constraint for xdebug in order to make builds deterministic. 

Builds for PHP5.6-dev are failing atm.