### PR TITLE
Re-add zip library for php 7.3

### DIFF
--- a/7.3/Dockerfile-cli
+++ b/7.3/Dockerfile-cli
@@ -18,7 +18,7 @@ RUN apk add --no-cache --virtual .dd-build-deps libpng-dev libjpeg-turbo-dev pos
   && chmod +x drupal.phar \
   && mv drupal.phar /usr/local/bin/drupal \
   && echo "export PATH=~/.composer/vendor/bin:\$PATH" >> ~/.bash_profile \
-  && apk add --no-cache sudo git libpng libjpeg libpq libxml2 mysql-client openssh-client rsync patch \
+  && apk add --no-cache sudo git libpng libjpeg libpq libxml2 mysql-client openssh-client rsync patch libzip-dev \
   && apk del .dd-build-deps
 
 COPY drupal-*.ini /usr/local/etc/php/conf.d/

--- a/7.3/Dockerfile-fpm
+++ b/7.3/Dockerfile-fpm
@@ -7,7 +7,7 @@ RUN apk add --no-cache --virtual .dd-build-deps libpng-dev libjpeg-turbo-dev pos
    && docker-php-ext-install opcache bcmath soap \
    && pecl install redis-3.1.1 \
    && docker-php-ext-enable redis \
-   && apk add --no-cache libpng libjpeg libpq libxml2 \
+   && apk add --no-cache libpng libjpeg libpq libxml2 libzip-dev  \
    && apk del .dd-build-deps
 
 COPY drupal-*.ini /usr/local/etc/php/conf.d/


### PR DESCRIPTION
So, here is a weird bug.

On php 7.3 it seems we have to add libzip-dev twice to get the extension to work.

Steps to reproduce:

```
$ docker run -it --rm drupaldocker/php:7.3-cli-2.x composer --version
PHP Warning:  PHP Startup: Unable to load dynamic library 'zip.so' (tried: /usr/local/lib/php/extensions/no-debug-non-zts-20180731/zip.so (Error loading shared library libzip.so.5: No such file or directory (needed by /usr/local/lib/php/extensions/no-debug-non-zts-20180731/zip.so)), /usr/local/lib/php/extensions/no-debug-non-zts-20180731/zip.so.so (Error loading shared library /usr/local/lib/php/extensions/no-debug-non-zts-20180731/zip.so.so: No such file or directory)) in Unknown on line 0
Do not run Composer as root/super user! See https://getcomposer.org/root for details
Composer version 1.8.0 2018-12-03 10:31:16
```

Test for fix:

```
$ docker run -it --rm drupaldocker/php:7.3-cli-2.x /bin/sh
/var/www/html # apk add libzip-dev && composer --version
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/community/x86_64/APKINDEX.tar.gz
(1/4) Installing pkgconf (1.5.3-r0)
(2/4) Installing zlib-dev (1.2.11-r1)
(3/4) Installing libzip (1.5.1-r1)
(4/4) Installing libzip-dev (1.5.1-r1)
Executing busybox-1.28.4-r1.trigger
OK: 70 MiB in 58 packages
Do not run Composer as root/super user! See https://getcomposer.org/root for details
Composer version 1.8.0 2018-12-03 10:31:16

```

Anyway. This does not occur on 7.2 (or other versions):

```
$ docker run -it --rm drupaldocker/php:7.2-cli-2.x composer --version
Do not run Composer as root/super user! See https://getcomposer.org/root for details
Composer version 1.8.0 2018-12-03 10:31:16
```

With the attached fix, the error no longer occurs for me.

Edited to clarify the part with the tested fix, where I ran a wrong command 😬 